### PR TITLE
Fixes #288: Incorrect number of Messier objects when viewing the 'observer overview'.

### DIFF
--- a/lib/observers.php
+++ b/lib/observers.php
@@ -112,8 +112,6 @@ class Observers {
 	public function showTopObservers($catalog, $rank) {
 		global $baseURL, $objObservation, $objUtil, $objObserver, $objObject, $DSOcatalogsLists;
 		$outputtable = "";
-		$objectsInCatalog = $objObject->getNumberOfObjectsInCatalog ( $catalog );
-		
 		if ($catalog != "") {
 			if (! strcmp ( $catalog, "-----------" )) {
 				echo "<div><table class=\"table sort-table table-condensed table-striped table-hover tablesorter custom-popup\">";
@@ -125,6 +123,8 @@ class Observers {
 			echo "<div><table class=\"table sort-table table-condensed table-striped table-hover tablesorter custom-popup\">";
 			$catalog = "M";
 		}
+		$objectsInCatalog = $objObject->getNumberOfObjectsInCatalog ( $catalog );
+		
 		echo "<thead>";
 		echo "<tr>";
 		echo "<th>" . LangTopObserversHeader1 . "</th>";

--- a/lib/sessions.php
+++ b/lib/sessions.php
@@ -84,7 +84,6 @@ class Sessions {
 			$start_ts = strtotime($session_begindate);
 			$end_ts = strtotime($session_enddate);
 			$user_ts = strtotime($begindate);
-			
 			// Check that user date is between start & end
 			if (($user_ts >= $start_ts) && ($user_ts <= $end_ts)) {
 				$return = true;


### PR DESCRIPTION
Fixes #288: Incorrect number of Messier objects when viewing the 'observer overview' 

Task-Url: http://github.com/DeepskyLog/DeepskyLog/issues/issue/288