### PR TITLE
Prevents caching on authentication and sensitive routes

### DIFF
--- a/deepskylog/app/Http/Kernel.php
+++ b/deepskylog/app/Http/Kernel.php
@@ -33,6 +33,7 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
+            \App\Http\Middleware\NoCacheForAuth::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,

--- a/deepskylog/app/Http/Middleware/NoCacheForAuth.php
+++ b/deepskylog/app/Http/Middleware/NoCacheForAuth.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class NoCacheForAuth
+{
+    /**
+     * Handle an incoming request.
+     *
+     * Prevent caching for authenticated users, non-GET requests and typical auth routes.
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        // Do not cache POST/PUT/PATCH/DELETE as they may change state or rely on fresh CSRF tokens
+        if (!in_array($request->method(), ['GET', 'HEAD'])) {
+            $request->attributes->set('responsecache.doNotCache', true);
+        }
+
+        // If user is authenticated, don't cache
+        if ($request->user()) {
+            $request->attributes->set('responsecache.doNotCache', true);
+        }
+
+        // Common auth routes we should ensure are never cached
+        $path = ltrim($request->path(), '/');
+        $authPaths = [
+            'login',
+            'logout',
+            'register',
+            'password/reset',
+            'password/email',
+            'password/confirm',
+        ];
+
+        foreach ($authPaths as $p) {
+            if ($path === $p || str_starts_with($path, rtrim($p, '/').'/')) {
+                $request->attributes->set('responsecache.doNotCache', true);
+                break;
+            }
+        }
+
+        $response = $next($request);
+
+        // Ensure HTTP cache headers prevent proxies and browsers from serving stale pages
+        $response->headers->set('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0');
+        $response->headers->set('Pragma', 'no-cache');
+        $response->headers->set('Expires', 'Thu, 01 Jan 1970 00:00:00 GMT');
+
+        return $response;
+    }
+}


### PR DESCRIPTION
Introduces middleware to disable browser and proxy caching for authenticated users, non-GET requests, and typical authentication endpoints. Enhances security by reducing risk of serving stale or sensitive content.