### PR TITLE
Prevents error when user is not authenticated

### DIFF
--- a/deepskylog/resources/views/observers/show.blade.php
+++ b/deepskylog/resources/views/observers/show.blade.php
@@ -194,11 +194,11 @@
                            <tr>
                            <td>{!! __("Number of equipment sets") !!}</td>
                                <td>
-                                   @if ($user->id === Auth::user()->id)
+                                   @if (Auth::user() && $user->id === Auth::user()->id)
                                        <a href="/instrumentset">
                                    @endif
                                 {{ $user->instrumentSets()->count() }}
-                                @if ($user->id === Auth::user()->id)
+                                @if (Auth::user() && $user->id === Auth::user()->id)
                                 </a>
                                 @endif
                                 </td>


### PR DESCRIPTION
Adds explicit check for an authenticated user before conditionally rendering equipment set link, preventing potential null reference errors on observer pages.