### PR TITLE
Logs CSRF token mismatch details for debugging

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -6,9 +6,11 @@
 
 + [ ] Log in on tablet redirects to the login page, and gives a Page Retired error.
 + [ ] Log in using Facebook, google, github does not work anymore...
++ [ ] Test registration
++ [ ] Test password reset
 + [ ] Targets
     + [ ] Create tables for deepsky and comet objects.
-    + [ ] Create extra tables
+    + [ ] Create extra tables for other objects (planets, sun, moon, moon features, ...)
     + [ ] Search targets, first by name, then by type, constellation, ...
 + [ ] Release new version of pyDeepskyLog
     + [ ] Should add a method to get the locations of a user, but only if authentication is implemented.


### PR DESCRIPTION
Adds detailed logging for CSRF token mismatches to aid in identifying causes of 419 errors from specific clients. Captures request metadata such as path, method, IP, user agent, and cookie presence, improving visibility into session-related issues.

Updates ToDo list with registration and password reset test tasks, and clarifies target table requirements.