### PR TITLE
Add logging for connected account updates

### DIFF
--- a/deepskylog/app/Actions/Socialstream/UpdateConnectedAccount.php
+++ b/deepskylog/app/Actions/Socialstream/UpdateConnectedAccount.php
@@ -17,6 +17,19 @@ class UpdateConnectedAccount implements UpdatesConnectedAccounts
     {
         Gate::forUser($user)->authorize('update', $connectedAccount);
 
+        try {
+            \Illuminate\Support\Facades\Log::info('oauth: updating connected account', [
+                'provider' => $provider,
+                'provider_id' => $providerUser->getId(),
+                'connected_account_id' => $connectedAccount->id ?? null,
+                'user_id' => is_object($user) ? $user->id : $user,
+                'session_id' => session()->getId(),
+                'session_cookie' => request()->cookie(config('session.cookie')),
+            ]);
+        } catch (\Throwable $e) {
+            // ignore logging errors
+        }
+
         $connectedAccount->forceFill([
             'provider' => strtolower($provider),
             'provider_id' => $providerUser->getId(),


### PR DESCRIPTION
Introduces info-level logging when updating a connected account via OAuth, capturing provider and session details for improved auditability and troubleshooting. Handles potential logging errors gracefully to avoid interrupting the update flow.