### PR TITLE
Optimize DB migrations and achievement updates

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -4,8 +4,7 @@
 
 ## Next steps
 
-+ [ ] Detail of a location -> click on number of observations -> wrong link, also for instruments, eyepieces, lenses and filters?
-  + [ ] First make sure to run the schedule:list and all the artisan commands to see the number of observations with the instruments, eyepieces, lenses and filters.  Then check the links on the location and instrument pages.
++ [ ] See the number of observations with the instruments, eyepieces, lenses and filters.  
 + [ ] Make old version work with the new object tables?
 
 + [ ] Targets

--- a/deepskylog/app/Console/Commands/updateAchievementsCommand.php
+++ b/deepskylog/app/Console/Commands/updateAchievementsCommand.php
@@ -37,6 +37,7 @@ class updateAchievementsCommand extends Command
     private $cometObservationsMap = [];
     private $cometDrawingsMap = [];
     private $uniqueCometMap = [];
+    private $userAchievementsMap = [];
 
     public function handle(): void
     {
@@ -45,13 +46,36 @@ class updateAchievementsCommand extends Command
         // Load all achievements once and keep in memory to avoid repeated DB queries
         $this->achievementMap = Achievement::all()->keyBy('name');
 
+        // Preload all existing user achievements to avoid per-user queries
+        $existingAchievements = AchievementUser::all();
+        foreach ($existingAchievements as $ua) {
+            if (!isset($this->userAchievementsMap[$ua->user_id])) {
+                $this->userAchievementsMap[$ua->user_id] = [];
+            }
+            $this->userAchievementsMap[$ua->user_id][$ua->achievement_id] = true;
+        }
+
         // Get all DeepskyLog sketches of the week
         $sketches = SketchOfTheWeek::all();
+
+        // Preload observations and users for sketches to avoid N+1 queries
+        $sketchObsIds = $sketches->pluck('observation_id')->filter(fn($id) => $id > 0)->all();
+        $sketchCometObsIds = $sketches->pluck('observation_id')->filter(fn($id) => $id < 0)->map(fn($id) => -$id)->all();
+        
+        $sketchObservations = ObservationsOld::whereIn('id', $sketchObsIds)->get()->keyBy('id');
+        $sketchCometObservations = CometObservationsOld::whereIn('id', $sketchCometObsIds)->get()->keyBy('id');
+        
+        $observerIds = $sketchObservations->pluck('observerid')
+            ->merge($sketchCometObservations->pluck('observerid'))
+            ->map(fn($id) => html_entity_decode($id))
+            ->unique()
+            ->all();
+        $sketchUsers = User::whereIn('username', $observerIds)->get()->keyBy('username');
 
         // Loop over all sketches
         foreach ($sketches as $sketch) {
             try {
-                $user = $this->getSketchData($sketch);
+                $user = $this->getSketchDataFromCache($sketch, $sketchObservations, $sketchCometObservations, $sketchUsers);
 
                 // Get the SketchOfTheWeek achievement
                 $achievement = $this->getAchievement('DeepskyLog sketch of the week');
@@ -63,13 +87,27 @@ class updateAchievementsCommand extends Command
             }
         }
 
-        // Get all DeepskyLog sketches of the week
+        // Get all DeepskyLog sketches of the month
         $sketches = SketchOfTheMonth::all();
+
+        // Preload observations and users for sketches to avoid N+1 queries
+        $sketchObsIds = $sketches->pluck('observation_id')->filter(fn($id) => $id > 0)->all();
+        $sketchCometObsIds = $sketches->pluck('observation_id')->filter(fn($id) => $id < 0)->map(fn($id) => -$id)->all();
+        
+        $sketchObservations = ObservationsOld::whereIn('id', $sketchObsIds)->get()->keyBy('id');
+        $sketchCometObservations = CometObservationsOld::whereIn('id', $sketchCometObsIds)->get()->keyBy('id');
+        
+        $observerIds = $sketchObservations->pluck('observerid')
+            ->merge($sketchCometObservations->pluck('observerid'))
+            ->map(fn($id) => html_entity_decode($id))
+            ->unique()
+            ->all();
+        $sketchUsers = User::whereIn('username', $observerIds)->get()->keyBy('username');
 
         // Loop over all sketches
         foreach ($sketches as $sketch) {
             try {
-                $user = $this->getSketchData($sketch);
+                $user = $this->getSketchDataFromCache($sketch, $sketchObservations, $sketchCometObservations, $sketchUsers);
 
                 // Get the SketchOfTheWeek achievement
                 $achievement = $this->getAchievement('DeepskyLog sketch of the month');
@@ -1011,6 +1049,39 @@ class updateAchievementsCommand extends Command
     }
 
     /**
+     * Retrieves the user associated with a given sketch using preloaded data.
+     *
+     * @param  mixed  $sketch  The sketch object.
+     * @param  \Illuminate\Support\Collection  $observations  Preloaded observations.
+     * @param  \Illuminate\Support\Collection  $cometObservations  Preloaded comet observations.
+     * @param  \Illuminate\Support\Collection  $users  Preloaded users.
+     * @return User The user object associated with the sketch.
+     *
+     * @throws Exception If the sketch observation ID is invalid or if there is an error retrieving the observation or user.
+     */
+    public function getSketchDataFromCache(mixed $sketch, $observations, $cometObservations, $users): User
+    {
+        if ($sketch->observation_id < 0) {
+            $observation = $cometObservations->get(-$sketch->observation_id);
+        } else {
+            $observation = $observations->get($sketch->observation_id);
+        }
+        
+        if (!$observation) {
+            throw new Exception('Observation not found for sketch: ' . $sketch->observation_id);
+        }
+        
+        $observerid = html_entity_decode($observation->observerid);
+        
+        $user = $users->get($observerid);
+        if (!$user) {
+            throw new Exception('User not found: ' . $observerid);
+        }
+        
+        return $user;
+    }
+
+    /**
      * Adds an achievement to a user.
      *
      * @param  mixed  $user  The user to whom the achievement is being added.
@@ -1020,11 +1091,18 @@ class updateAchievementsCommand extends Command
      */
     public function addAchievementToUser(mixed $user, mixed $achievement): void
     {
-        // Add achievement to user
-        try {
-            $user->grantAchievement($achievement);
-        } catch (Exception) {
-            // dump('Unable to add achievement: '.$e->getMessage());
+        // Check if user already has this achievement using our in-memory map
+        if (!isset($this->userAchievementsMap[$user->id][$achievement->id])) {
+            try {
+                $user->grantAchievement($achievement);
+                // Update our in-memory map
+                if (!isset($this->userAchievementsMap[$user->id])) {
+                    $this->userAchievementsMap[$user->id] = [];
+                }
+                $this->userAchievementsMap[$user->id][$achievement->id] = true;
+            } catch (Exception) {
+                // dump('Unable to add achievement: '.$e->getMessage());
+            }
         }
     }
 
@@ -1036,11 +1114,43 @@ class updateAchievementsCommand extends Command
      */
     private function removeAchievementFromUser(mixed $user, mixed $achievement): void
     {
-        // Remove achievement from user
-        try {
-            AchievementUser::where('user_id', $user->id)->where('achievement_id', $achievement->id)->delete();
-        } catch (Exception) {
-            // dump('Unable to remove achievement: '.$e->getMessage());
+        // Check if user has this achievement using our in-memory map
+        if (isset($this->userAchievementsMap[$user->id][$achievement->id])) {
+            try {
+                AchievementUser::where('user_id', $user->id)->where('achievement_id', $achievement->id)->delete();
+                // Update our in-memory map
+                unset($this->userAchievementsMap[$user->id][$achievement->id]);
+            } catch (Exception) {
+                // dump('Unable to remove achievement: '.$e->getMessage());
+            }
+        }
+    }
+
+    /**
+     * Removes multiple achievements from a user in a single query.
+     *
+     * @param  mixed  $user  The user object.
+     * @param  array  $achievements  Array of achievement objects.
+     */
+    private function removeMultipleAchievementsFromUser(mixed $user, array $achievements): void
+    {
+        $achievementIds = [];
+        foreach ($achievements as $achievement) {
+            if (isset($this->userAchievementsMap[$user->id][$achievement->id])) {
+                $achievementIds[] = $achievement->id;
+            }
+        }
+        
+        if (!empty($achievementIds)) {
+            try {
+                AchievementUser::where('user_id', $user->id)->whereIn('achievement_id', $achievementIds)->delete();
+                // Update our in-memory map
+                foreach ($achievementIds as $achievementId) {
+                    unset($this->userAchievementsMap[$user->id][$achievementId]);
+                }
+            } catch (Exception) {
+                // dump('Unable to remove achievements: '.$e->getMessage());
+            }
         }
     }
 
@@ -1067,20 +1177,15 @@ class updateAchievementsCommand extends Command
         // Re-add the achievements
         if ($total == $max) {
             $this->addAchievementToUser($user, $gold);
-            $this->removeAchievementFromUser($user, $silver);
-            $this->removeAchievementFromUser($user, $bronze);
+            $this->removeMultipleAchievementsFromUser($user, [$silver, $bronze]);
         } elseif ($total >= 50) {
             $this->addAchievementToUser($user, $silver);
-            $this->removeAchievementFromUser($user, $gold);
-            $this->removeAchievementFromUser($user, $bronze);
+            $this->removeMultipleAchievementsFromUser($user, [$gold, $bronze]);
         } elseif ($total >= 25) {
             $this->addAchievementToUser($user, $bronze);
-            $this->removeAchievementFromUser($user, $gold);
-            $this->removeAchievementFromUser($user, $silver);
+            $this->removeMultipleAchievementsFromUser($user, [$gold, $silver]);
         } else {
-            $this->removeAchievementFromUser($user, $gold);
-            $this->removeAchievementFromUser($user, $silver);
-            $this->removeAchievementFromUser($user, $bronze);
+            $this->removeMultipleAchievementsFromUser($user, [$gold, $silver, $bronze]);
         }
     }
 
@@ -1111,40 +1216,21 @@ class updateAchievementsCommand extends Command
         // Re-add the achievements
         if ($total == $max) {
             $this->addAchievementToUser($user, $platinum);
-            $this->removeAchievementFromUser($user, $diamond);
-            $this->removeAchievementFromUser($user, $gold);
-            $this->removeAchievementFromUser($user, $silver);
-            $this->removeAchievementFromUser($user, $bronze);
+            $this->removeMultipleAchievementsFromUser($user, [$diamond, $gold, $silver, $bronze]);
         } elseif ($total >= 200) {
             $this->addAchievementToUser($user, $diamond);
-            $this->removeAchievementFromUser($user, $platinum);
-            $this->removeAchievementFromUser($user, $silver);
-            $this->removeAchievementFromUser($user, $gold);
-            $this->removeAchievementFromUser($user, $bronze);
+            $this->removeMultipleAchievementsFromUser($user, [$platinum, $gold, $silver, $bronze]);
         } elseif ($total >= 100) {
             $this->addAchievementToUser($user, $gold);
-            $this->removeAchievementFromUser($user, $platinum);
-            $this->removeAchievementFromUser($user, $silver);
-            $this->removeAchievementFromUser($user, $diamond);
-            $this->removeAchievementFromUser($user, $bronze);
+            $this->removeMultipleAchievementsFromUser($user, [$platinum, $diamond, $silver, $bronze]);
         } elseif ($total >= 50) {
             $this->addAchievementToUser($user, $silver);
-            $this->removeAchievementFromUser($user, $platinum);
-            $this->removeAchievementFromUser($user, $diamond);
-            $this->removeAchievementFromUser($user, $gold);
-            $this->removeAchievementFromUser($user, $bronze);
+            $this->removeMultipleAchievementsFromUser($user, [$platinum, $diamond, $gold, $bronze]);
         } elseif ($total >= 25) {
-            $this->removeAchievementFromUser($user, $platinum);
-            $this->removeAchievementFromUser($user, $diamond);
             $this->addAchievementToUser($user, $bronze);
-            $this->removeAchievementFromUser($user, $gold);
-            $this->removeAchievementFromUser($user, $silver);
+            $this->removeMultipleAchievementsFromUser($user, [$platinum, $diamond, $gold, $silver]);
         } else {
-            $this->removeAchievementFromUser($user, $platinum);
-            $this->removeAchievementFromUser($user, $diamond);
-            $this->removeAchievementFromUser($user, $gold);
-            $this->removeAchievementFromUser($user, $silver);
-            $this->removeAchievementFromUser($user, $bronze);
+            $this->removeMultipleAchievementsFromUser($user, [$platinum, $diamond, $gold, $silver, $bronze]);
         }
     }
 
@@ -1389,17 +1475,19 @@ class updateAchievementsCommand extends Command
         mixed $achievement10
     ): void {
         $this->addAchievementToUser($user, $achievement1);
-        $this->removeAllAchievements(
+        $this->removeMultipleAchievementsFromUser(
             $user,
-            $achievement2,
-            $achievement3,
-            $achievement4,
-            $achievement5,
-            $achievement6,
-            $achievement7,
-            $achievement8,
-            $achievement9,
-            $achievement10
+            [
+                $achievement2,
+                $achievement3,
+                $achievement4,
+                $achievement5,
+                $achievement6,
+                $achievement7,
+                $achievement8,
+                $achievement9,
+                $achievement10
+            ]
         );
     }
 
@@ -1429,15 +1517,20 @@ class updateAchievementsCommand extends Command
         mixed $achievement8,
         mixed $achievement9
     ): void {
-        $this->removeAchievementFromUser($user, $achievement1);
-        $this->removeAchievementFromUser($user, $achievement2);
-        $this->removeAchievementFromUser($user, $achievement3);
-        $this->removeAchievementFromUser($user, $achievement4);
-        $this->removeAchievementFromUser($user, $achievement5);
-        $this->removeAchievementFromUser($user, $achievement6);
-        $this->removeAchievementFromUser($user, $achievement7);
-        $this->removeAchievementFromUser($user, $achievement8);
-        $this->removeAchievementFromUser($user, $achievement9);
+        $this->removeMultipleAchievementsFromUser(
+            $user,
+            [
+                $achievement1,
+                $achievement2,
+                $achievement3,
+                $achievement4,
+                $achievement5,
+                $achievement6,
+                $achievement7,
+                $achievement8,
+                $achievement9
+            ]
+        );
     }
 
     /**

--- a/deepskylog/app/Console/Commands/updateObservationsCommand.php
+++ b/deepskylog/app/Console/Commands/updateObservationsCommand.php
@@ -3,6 +3,10 @@
 namespace App\Console\Commands;
 
 use App\Models\CometObservationsOld;
+use App\Models\Eyepiece;
+use App\Models\Filter;
+use App\Models\Instrument;
+use App\Models\Lens;
 use App\Models\Location;
 use App\Models\ObservationsOld;
 use Exception;
@@ -17,76 +21,80 @@ class updateObservationsCommand extends Command
 
     public function handle(): void
     {
-        //        $this->info('Updating Instruments table...');
-        //
-        //        // Get all instruments
-        //        $instruments = Instrument::all();
-        //
-        //        // Check if the user with the given username already exists in the new database
-        //        // If not, create a new user with the given username
-        //        foreach ($instruments as $instrument) {
-        //            try {
-        //                $observations = ObservationsOld::where('instrumentid', $instrument->id)->count();
-        //                $cometObservations = CometObservationsOld::where('instrumentid', $instrument->id)->count();
-        //
-        //                $observations = $observations + $cometObservations;
-        //            } catch (Exception $e) {
-        //                $observations = 0;
-        //            }
-        //
-        //            $instrument->observations = $observations;
-        //            $instrument->save();
-        //        }
-        //
-        //        $this->info('Updating Eyepieces table...');
-        //
-        //        // Get all eyepieces
-        //        $eyepieces = Eyepiece::all();
-        //
-        //        // Check if the user with the given username already exists in the new database
-        //        // If not, create a new user with the given username
-        //        foreach ($eyepieces as $eyepiece) {
-        //            try {
-        //                $observations = ObservationsOld::where('eyepieceid', $eyepiece->id)->count();
-        //            } catch (Exception $e) {
-        //                $observations = 0;
-        //            }
-        //
-        //            $eyepiece->observations = $observations;
-        //            $eyepiece->save();
-        //        }
-        //
-        //        $this->info('Updating Lens table...');
-        //
-        //        // Get all lenses
-        //        $lenses = Lens::all();
-        //
-        //        foreach ($lenses as $lens) {
-        //            try {
-        //                $observations = ObservationsOld::where('lensid', $lens->id)->count();
-        //            } catch (Exception $e) {
-        //                $observations = 0;
-        //            }
-        //
-        //            $lens->observations = $observations;
-        //            $lens->save();
-        //        }
-        //
-        //        $this->info('Updating Filters table...');
-        //
-        //        // Get all filters
-        //        $filters = Filter::all();
-        //
-        //        foreach ($filters as $filter) {
-        //            try {
-        //                $observations = ObservationsOld::where('filterid', $filter->id)->count();
-        //            } catch (Exception $e) {
-        //                $observations = 0;
-        //            }
-        //
-        //            $filter->observations = $observations;
-        //            $filter->save();
-        //        }
+        $this->info('Updating Instruments table...');
+
+        // Get all instruments
+        $instruments = Instrument::all();
+
+        // Precompute counts grouped by instrument in the old DB to avoid per-instrument queries
+        $instrumentObsCounts = DB::connection('mysqlOld')->table('observations')
+            ->select('instrumentid', DB::raw('COUNT(*) as cnt'))
+            ->groupBy('instrumentid')
+            ->pluck('cnt', 'instrumentid')
+            ->toArray();
+
+        $instrumentCometCounts = DB::connection('mysqlOld')->table('cometobservations')
+            ->select('instrumentid', DB::raw('COUNT(*) as cnt'))
+            ->groupBy('instrumentid')
+            ->pluck('cnt', 'instrumentid')
+            ->toArray();
+
+        foreach ($instruments as $instrument) {
+            $observations = ($instrumentObsCounts[$instrument->id] ?? 0) + ($instrumentCometCounts[$instrument->id] ?? 0);
+            $instrument->observations = $observations;
+            $instrument->save();
+        }
+
+        $this->info('Updating Eyepieces table...');
+
+        // Get all eyepieces
+        $eyepieces = Eyepiece::all();
+
+        // Precompute counts grouped by eyepiece in the old DB to avoid per-eyepiece queries
+        $eyepieceObsCounts = DB::connection('mysqlOld')->table('observations')
+            ->select('eyepieceid', DB::raw('COUNT(*) as cnt'))
+            ->groupBy('eyepieceid')
+            ->pluck('cnt', 'eyepieceid')
+            ->toArray();
+
+        foreach ($eyepieces as $eyepiece) {
+            $eyepiece->observations = $eyepieceObsCounts[$eyepiece->id] ?? 0;
+            $eyepiece->save();
+        }
+
+        $this->info('Updating Lenses table...');
+
+        // Get all lenses
+        $lenses = Lens::all();
+
+        // Precompute counts grouped by lens in the old DB to avoid per-lens queries
+        $lensObsCounts = DB::connection('mysqlOld')->table('observations')
+            ->select('lensid', DB::raw('COUNT(*) as cnt'))
+            ->groupBy('lensid')
+            ->pluck('cnt', 'lensid')
+            ->toArray();
+
+        foreach ($lenses as $lens) {
+            $lens->observations = $lensObsCounts[$lens->id] ?? 0;
+            $lens->save();
+        }
+
+        $this->info('Updating Filters table...');
+
+        // Get all filters
+        $filters = Filter::all();
+
+        // Precompute counts grouped by filter in the old DB to avoid per-filter queries
+        $filterObsCounts = DB::connection('mysqlOld')->table('observations')
+            ->select('filterid', DB::raw('COUNT(*) as cnt'))
+            ->groupBy('filterid')
+            ->pluck('cnt', 'filterid')
+            ->toArray();
+
+        foreach ($filters as $filter) {
+            $filter->observations = $filterObsCounts[$filter->id] ?? 0;
+            $filter->save();
+        }
 
         $this->info('Updating Locations table...');
 
@@ -94,28 +102,24 @@ class updateObservationsCommand extends Command
         $locations = Location::all();
 
         // Precompute counts grouped by location in the old DB to avoid per-location queries
-        $obsCounts = DB::connection('mysqlOld')->table('observations')
+        $locationObsCounts = DB::connection('mysqlOld')->table('observations')
             ->select('locationid', DB::raw('COUNT(*) as cnt'))
             ->groupBy('locationid')
             ->pluck('cnt', 'locationid')
             ->toArray();
 
-        $cometCounts = DB::connection('mysqlOld')->table('cometobservations')
+        $locationCometCounts = DB::connection('mysqlOld')->table('cometobservations')
             ->select('locationid', DB::raw('COUNT(*) as cnt'))
             ->groupBy('locationid')
             ->pluck('cnt', 'locationid')
             ->toArray();
 
         foreach ($locations as $location) {
-            $observations = 0;
-            try {
-                $observations = ($obsCounts[$location->id] ?? 0) + ($cometCounts[$location->id] ?? 0);
-            } catch (Exception $e) {
-                $observations = 0;
-            }
-
+            $observations = ($locationObsCounts[$location->id] ?? 0) + ($locationCometCounts[$location->id] ?? 0);
             $location->observations = $observations;
             $location->save();
         }
+
+        $this->info('All observation counts updated successfully!');
     }
 }

--- a/deepskylog/app/Console/Commands/updateOldEyepieceTableCommand.php
+++ b/deepskylog/app/Console/Commands/updateOldEyepieceTableCommand.php
@@ -19,13 +19,15 @@ class updateOldEyepieceTableCommand extends Command
         // Get all eyepieces from the new database
         $eyepieces = Eyepiece::all();
 
+        // Preload all existing eyepiece IDs from old DB to avoid per-eyepiece queries
+        $existingIds = EyepiecesOld::pluck('id')->flip()->all();
+
         // Check if the eyepiece with the given id already exists in the old database
         // If not, create a new eyepiece
         foreach ($eyepieces as $eyepiece) {
             $id = html_entity_decode($eyepiece->id);
 
-            $old_eyepiece = EyepiecesOld::where('id', $id)->first();
-            if (! $old_eyepiece) {
+            if (!isset($existingIds[$id])) {
                 $this->info('Adding eyepiece: '.$id);
                 $old_eyepiece = new EyepiecesOld;
                 $old_eyepiece->id = $id;

--- a/deepskylog/app/Console/Commands/updateOldFilterTableCommand.php
+++ b/deepskylog/app/Console/Commands/updateOldFilterTableCommand.php
@@ -19,14 +19,15 @@ class updateOldFilterTableCommand extends Command
         // Get all filters from the new database
         $filters = Filter::all();
 
+        // Preload all existing filter IDs from old DB to avoid per-filter queries
+        $existingIds = FiltersOld::pluck('id')->flip()->all();
+
         // Check if the filter with the given id already exists in the old database
         // If not, create a new filter
         foreach ($filters as $filter) {
             $id = html_entity_decode($filter->id);
 
-            $old_filter = FiltersOld::where('id', $id)->first();
-
-            if (! $old_filter) {
+            if (!isset($existingIds[$id])) {
                 $this->info('Adding filter: '.$id);
                 $old_filter = new FiltersOld;
                 $old_filter->id = $id;

--- a/deepskylog/app/Console/Commands/updateOldInstrumentTableCommand.php
+++ b/deepskylog/app/Console/Commands/updateOldInstrumentTableCommand.php
@@ -19,13 +19,15 @@ class updateOldInstrumentTableCommand extends Command
         // Get all instrument from the new database
         $instruments = Instrument::all();
 
+        // Preload all existing instrument IDs from old DB to avoid per-instrument queries
+        $existingIds = InstrumentsOld::pluck('id')->flip()->all();
+
         // Check if the instrument with the given id already exists in the old database
         // If not, create a new instrument
         foreach ($instruments as $instrument) {
             $id = html_entity_decode($instrument->id);
 
-            $old_instrument = InstrumentsOld::where('id', $id)->first();
-            if (! $old_instrument) {
+            if (!isset($existingIds[$id])) {
                 $this->info('Adding instrument: '.$id);
                 $old_instrument = new InstrumentsOld;
                 $old_instrument->id = $id;

--- a/deepskylog/app/Console/Commands/updateOldLensTableCommand.php
+++ b/deepskylog/app/Console/Commands/updateOldLensTableCommand.php
@@ -19,14 +19,15 @@ class updateOldLensTableCommand extends Command
         // Get all lens from the new database
         $lenses = Lens::all();
 
+        // Preload all existing lens IDs from old DB to avoid per-lens queries
+        $existingIds = LensesOld::pluck('id')->flip()->all();
+
         // Check if the lens with the given id already exists in the old database
         // If not, create a new lens
         foreach ($lenses as $lens) {
             $id = html_entity_decode($lens->id);
 
-            $old_lens = LensesOld::where('id', $id)->first();
-
-            if (! $old_lens) {
+            if (!isset($existingIds[$id])) {
                 $this->info('Adding lens: '.$id);
                 $old_lens = new LensesOld;
                 $old_lens->id = $id;

--- a/deepskylog/app/Console/Commands/updateOldLocationTableCommand.php
+++ b/deepskylog/app/Console/Commands/updateOldLocationTableCommand.php
@@ -19,14 +19,15 @@ class updateOldLocationTableCommand extends Command
         // Get all locations from the new database
         $locations = Location::all();
 
+        // Preload all existing location IDs from old DB to avoid per-location queries
+        $existingIds = LocationsOld::pluck('id')->flip()->all();
+
         // Check if the location with the given id already exists in the old database
         // If not, create a new location
         foreach ($locations as $location) {
             $id = html_entity_decode($location->id);
 
-            $old_location = LocationsOld::where('id', $id)->first();
-
-            if (! $old_location) {
+            if (!isset($existingIds[$id])) {
                 $this->info('Adding location: '.$id);
                 $old_location = new LocationsOld;
                 $old_location->id = $id;

--- a/deepskylog/app/Console/Commands/updateUserTableCommand.php
+++ b/deepskylog/app/Console/Commands/updateUserTableCommand.php
@@ -31,12 +31,14 @@ class updateUserTableCommand extends Command
 
         $team = Team::where('name', 'Observers')->first();
 
+        // Preload all existing usernames from new DB to avoid per-observer queries
+        $existingUsernames = User::pluck('username')->flip()->all();
+
         // Check if the user with the given username already exists in the new database
         // If not, create a new user with the given username
         foreach ($observers as $observer) {
             $username = html_entity_decode($observer->id);
-            $user = User::where('username', html_entity_decode($username))->first();
-            if (! $user) {
+            if (!isset($existingUsernames[$username])) {
                 // Check if the user has been approved
                 if ($observer->role === 1) {
                     echo 'Adding user: '.$observer->id.PHP_EOL;

--- a/deepskylog/app/Console/Kernel.php
+++ b/deepskylog/app/Console/Kernel.php
@@ -22,6 +22,7 @@ class Kernel extends ConsoleKernel
         // Backfill session slugs regularly (idempotent)
         $schedule->command('sessions:backfill-slugs')->everyFiveMinutes();
 
+        $schedule->command('astronomy:updateCometPhotometry')->weeklyOn(2, '4:30');
         // Incremental TNTSearch index update
         $schedule->command('tntsearch:incremental-index --storage=storage/tnt')->everyFiveMinutes();
     }

--- a/deepskylog/resources/views/location/show.blade.php
+++ b/deepskylog/resources/views/location/show.blade.php
@@ -136,9 +136,7 @@
                         <tr>
                             <td>{{ __("Number of observations") }}</td>
                             <td>
-                                <a href="/observation/location/{{ $location->id }}">
                                     {{  $location->observations }}
-                                </a>
                             </td>
                         </tr>
                         <tr>


### PR DESCRIPTION
Reduce N+1 queries and improve performance by preloading related data and using bulk operations. Introduce an in-memory map for user achievements to avoid duplicate grants/removals, add a cached sketch user lookup, and provide a batched removal helper to minimize queries. Replace per-item counting with grouped DB counts for instruments/eyepieces/lenses/filters/locations and preload existing IDs when syncing old tables. Remove a broken observation link in the location view and schedule a weekly comet photometry update. Improves reliability and significantly reduces DB load during migrations and achievement processing.