### PR TITLE
Adds catalogs browsing page with Livewire search and backend support

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -4,8 +4,8 @@
 
 ## Next steps
 
++ [ ] Changing or adding sessions is very slow on the real server...
 + [ ] Targets
-  + [ ] Catalogs page
   + [ ] Search targets, first by name, then by type, constellation, ...
   + [ ] Install sqlite3 on the server to be able to use TNTSearch
   + [ ] After installation, make sure to run the queue worker to compute the contrast reserve and optimum eyepieces for all users / instruments / locations.  See Tips.md for more information about the queue worker.

--- a/deepskylog/app/Http/Controllers/CatalogController.php
+++ b/deepskylog/app/Http/Controllers/CatalogController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class CatalogController extends Controller
+{
+    public function index(Request $request)
+    {
+        // The Livewire component handles querying and rendering the page.
+        return view('catalogs.index');
+    }
+}

--- a/deepskylog/app/Http/Livewire/CatalogsPage.php
+++ b/deepskylog/app/Http/Livewire/CatalogsPage.php
@@ -1,0 +1,392 @@
+<?php
+
+namespace App\Http\Livewire;
+
+use Livewire\Component;
+use Livewire\WithPagination;
+use Illuminate\Support\Facades\DB;
+
+class CatalogsPage extends Component
+{
+    use WithPagination;
+
+    public $search = '';
+    public $selected = '';
+    public $perPage = 50;
+    public $open = false;
+
+    protected $queryString = ['selected'];
+
+    protected $listeners = [
+        'selectCatalog' => 'selectCatalog'
+    ];
+
+    public function mount()
+    {
+        $this->selected = request()->query('catalog', $this->selected);
+    }
+
+    public function updatingSearch()
+    {
+        $this->resetPage();
+    }
+
+    public function updatedSearch()
+    {
+        // Open the suggestion list when the user types
+        $this->open = true;
+        $this->resetPage();
+    }
+
+    public function selectCatalog($catalog)
+    {
+        $this->selected = $catalog;
+        $this->resetPage();
+        $this->open = false;
+    }
+
+    public function clearSelection()
+    {
+        $this->selected = '';
+        $this->search = '';
+        $this->resetPage();
+        $this->open = false;
+    }
+
+    public function render()
+    {
+        // All distinct catalogs for suggestion list (filtered by search)
+        $catalogQuery = DB::table('objectnames')
+            ->select('catalog')
+            ->whereNotNull('catalog')
+            ->where('catalog', '!=', '');
+
+        if (trim($this->search) !== '') {
+            $catalogQuery->where('catalog', 'like', '%' . $this->search . '%');
+        }
+
+        $catalogs = $catalogQuery->distinct()->orderBy('catalog')->limit(200)->pluck('catalog')->toArray();
+
+        // Also include catalogs from the legacy DB if available (some catalogs still live there)
+        try {
+            $old = DB::connection('mysqlOld')->table('objectnames')
+                ->select('catalog')
+                ->whereNotNull('catalog')
+                ->where('catalog', '!=', '')
+                ->distinct()
+                ->orderBy('catalog')
+                ->limit(200)
+                ->pluck('catalog')
+                ->toArray();
+            $catalogs = array_unique(array_merge($catalogs, $old));
+        } catch (\Throwable $_) {
+            // ignore if legacy connection not configured
+        }
+
+        $catalogs = collect($catalogs)->sort()->values();
+
+        $constellationCounts = collect();
+        $typeCounts = collect();
+        $objects = null;
+
+        if (!empty($this->selected)) {
+            // Resolve catalog variants: some rows use short code like 'C' while others use 'Caldwell'.
+            $catalogVariants = DB::table('objectnames')
+                ->whereRaw('LOWER(catalog) = ?', [strtolower($this->selected)])
+                ->orWhere('catalog', 'like', $this->selected . '%')
+                ->orWhere('catalog', 'like', '%' . $this->selected)
+                ->distinct()
+                ->pluck('catalog')
+                ->toArray();
+
+            try {
+                $oldCats = DB::connection('mysqlOld')->table('objectnames')
+                    ->whereRaw('LOWER(catalog) = ?', [strtolower($this->selected)])
+                    ->orWhere('catalog', 'like', $this->selected . '%')
+                    ->orWhere('catalog', 'like', '%' . $this->selected)
+                    ->distinct()
+                    ->pluck('catalog')
+                    ->toArray();
+                $catalogVariants = array_unique(array_merge($catalogVariants, $oldCats));
+            } catch (\Throwable $_) {
+                // ignore
+            }
+
+            if (empty($catalogVariants)) {
+                $catalogVariants = [$this->selected];
+            }
+            // Gather slugs from primary objectnames table
+            $slugs = DB::table('objectnames')
+                ->whereIn('catalog', $catalogVariants)
+                ->whereNotNull('slug')
+                ->distinct()
+                ->pluck('slug')
+                ->toArray();
+
+            // Also gather slugs from legacy objectnames if present
+            try {
+                $oldSlugs = DB::connection('mysqlOld')->table('objectnames')
+                    ->whereIn('catalog', $catalogVariants)
+                    ->whereNotNull('slug')
+                    ->distinct()
+                    ->pluck('slug')
+                    ->toArray();
+                $slugs = array_unique(array_merge($slugs, $oldSlugs));
+            } catch (\Throwable $_) {
+                // ignore
+            }
+
+            // Ensure non-empty and remove null/empty values
+            $slugs = array_values(array_filter($slugs, function ($s) {
+                return !empty($s); }));
+
+            // If slugs are missing for many entries, try a fallback: match objects.name
+            // against objectnames.objectname and objectnames.altname from primary and legacy tables.
+            try {
+                // Collect canonical and alt names from primary
+                $names = DB::table('objectnames')
+                    ->whereIn('catalog', $catalogVariants)
+                    ->pluck('objectname')
+                    ->toArray();
+                $alt = DB::table('objectnames')
+                    ->whereIn('catalog', $catalogVariants)
+                    ->pluck('altname')
+                    ->toArray();
+                $names = array_filter(array_unique(array_merge($names, $alt)));
+
+                // Merge legacy names if available
+                try {
+                    $oldNames = DB::connection('mysqlOld')->table('objectnames')
+                        ->whereIn('catalog', $catalogVariants)
+                        ->pluck('objectname')
+                        ->toArray();
+                    $oldAlt = DB::connection('mysqlOld')->table('objectnames')
+                        ->whereIn('catalog', $catalogVariants)
+                        ->pluck('altname')
+                        ->toArray();
+                    $names = array_filter(array_unique(array_merge($names, $oldNames, $oldAlt)));
+                } catch (\Throwable $_) {
+                    // ignore
+                }
+
+                if (!empty($names)) {
+                    $foundSlugs = DB::table('objects')
+                        ->whereIn('name', $names)
+                        ->distinct()
+                        ->pluck('slug')
+                        ->toArray();
+
+                    if (!empty($foundSlugs)) {
+                        $slugs = array_unique(array_merge($slugs, $foundSlugs));
+                    }
+                }
+            } catch (\Throwable $_) {
+                // ignore fallback failures
+            }
+
+            // If no slugs found, return empty results to avoid invalid SQL
+            if (empty($slugs)) {
+                $objects = new \Illuminate\Pagination\LengthAwarePaginator([], 0, $this->perPage);
+                $constellationCounts = collect();
+                $typeCounts = collect();
+            } else {
+                // Constellation counts derived from objects that have any matching objectname (slug)
+                $constellationCounts = DB::table('objects')
+                    ->leftJoin('constellations', 'objects.con', '=', 'constellations.id')
+                    ->whereIn('objects.slug', $slugs)
+                    ->select('constellations.id as con_id', 'constellations.name as constellation', DB::raw('COUNT(DISTINCT objects.slug) as total'))
+                    ->groupBy('constellations.id', 'constellations.name')
+                    ->whereNotNull('constellations.name')
+                    ->orderByDesc('total')
+                    ->get();
+
+                $typeCounts = DB::table('objects')
+                    ->leftJoin('target_types', 'objects.type', '=', 'target_types.id')
+                    ->whereIn('objects.slug', $slugs)
+                    ->select('target_types.type as type_name', DB::raw('COUNT(DISTINCT objects.slug) as total'))
+                    ->groupBy('target_types.type')
+                    ->orderByDesc('total')
+                    ->get();
+
+                $prefixExpr = "LOWER(REGEXP_SUBSTR(objects.name, '^[^0-9]+'))";
+                $numExprAsc = "COALESCE(CAST(REGEXP_SUBSTR(objects.name, '[0-9]+') AS UNSIGNED), 4294967295)";
+                // Prefer numeric `oname.catindex` when it starts with digits; otherwise fall back to numeric in objects.name
+                $catIndexNumExpr = "CASE WHEN oname.catindex REGEXP '^[0-9]+' THEN CAST(REGEXP_SUBSTR(oname.catindex, '[0-9]+') AS UNSIGNED) WHEN REGEXP_SUBSTR(objects.name, '[0-9]+') IS NOT NULL THEN CAST(REGEXP_SUBSTR(objects.name, '[0-9]+') AS UNSIGNED) ELSE 4294967295 END";
+
+                // Join objectnames on objects.name = oname.objectname (not on slug, which differs between tables)
+                $objects = DB::table('objects')
+                    ->whereIn('objects.slug', $slugs)
+                    ->leftJoin('objectnames as oname', function ($join) use ($catalogVariants) {
+                        $join->on('objects.name', '=', 'oname.objectname')
+                            ->whereIn('oname.catalog', $catalogVariants);
+                    })
+                    ->leftJoin('constellations', 'objects.con', '=', 'constellations.id')
+                    ->leftJoin('target_types', 'objects.type', '=', 'target_types.id')
+                    ->select('objects.slug', 'objects.name', 'constellations.name as constellation', 'target_types.type as type_name', DB::raw('MIN(oname.catindex) as catindex'))
+                    ->groupBy('objects.slug', 'objects.name', 'constellations.name', 'target_types.type')
+                    // Order by numeric catindex when present, otherwise fall back to natural ordering on objects.name
+                    ->orderByRaw("{$catIndexNumExpr} ASC, {$prefixExpr} ASC, {$numExprAsc} ASC, objects.name ASC")
+                    ->paginate($this->perPage);
+            }
+        }
+
+        // Build display names for objects on the current page: prefer catalog-specific
+        // objectnames (primary, then legacy). Format: <catalog-specific name> (<main name>).
+        $displayNames = [];
+        if ($objects && $objects instanceof \Illuminate\Pagination\LengthAwarePaginator && $objects->total() > 0) {
+            $pageSlugs = collect($objects->items())->pluck('slug')->toArray();
+
+            if (!empty($pageSlugs)) {
+                // Primary objectnames by slug; prefer catalog index for display when available
+                $rows = DB::table('objectnames')
+                    ->whereIn('catalog', $catalogVariants)
+                    ->whereIn('slug', $pageSlugs)
+                    ->select('slug', 'objectname', 'altname', 'catindex')
+                    ->get();
+
+                foreach ($rows as $r) {
+                    $main = $r->objectname ?: $r->altname;
+                    if ($r->catindex && strlen(trim($r->catindex)) > 0) {
+                        $display = $this->selected . ' ' . trim($r->catindex);
+                    } elseif ($main) {
+                        // Fall back to using the catalog label + name when no index
+                        $cat = $this->selected;
+                        if (stripos($main, $cat) === 0) {
+                            $display = $main;
+                        } else {
+                            $display = $cat . ' ' . $main;
+                        }
+                    } else {
+                        continue;
+                    }
+
+                    $displayNames[$r->slug] = $display;
+                }
+
+                // Legacy objectnames (do not override primary)
+                try {
+                    $oldRows = DB::connection('mysqlOld')->table('objectnames')
+                        ->whereIn('catalog', $catalogVariants)
+                        ->whereIn('slug', $pageSlugs)
+                        ->select('slug', 'objectname', 'altname', 'catindex')
+                        ->get();
+
+                    foreach ($oldRows as $r) {
+                        if (isset($displayNames[$r->slug]))
+                            continue;
+                        $main = $r->objectname ?: $r->altname;
+                        if ($r->catindex && strlen(trim($r->catindex)) > 0) {
+                            $display = $this->selected . ' ' . trim($r->catindex);
+                        } elseif ($main) {
+                            $cat = $this->selected;
+                            if (stripos($main, $cat) === 0) {
+                                $display = $main;
+                            } else {
+                                $display = $cat . ' ' . $main;
+                            }
+                        } else {
+                            continue;
+                        }
+                        $displayNames[$r->slug] = $display;
+                    }
+                } catch (\Throwable $_) {
+                    // ignore
+                }
+
+                // For any remaining slugs try joining on objects.name -> objectnames.objectname|altname
+                $missing = array_values(array_filter($pageSlugs, function ($s) use ($displayNames) {
+                    return !isset($displayNames[$s]); }));
+                if (!empty($missing)) {
+                    $joined = DB::table('objects as o')
+                        ->join('objectnames as n', function ($join) {
+                            $join->on('o.name', '=', 'n.objectname')->orOn('o.name', '=', 'n.altname');
+                        })
+                        ->whereIn('o.slug', $missing)
+                        ->whereIn('n.catalog', $catalogVariants)
+                        ->select('o.slug', 'n.objectname', 'n.altname', 'n.catindex')
+                        ->get();
+
+                    foreach ($joined as $r) {
+                        if (isset($displayNames[$r->slug]))
+                            continue;
+                        $main = $r->objectname ?: $r->altname;
+                        // joined rows may include catindex
+                        $catindex = property_exists($r, 'catindex') ? $r->catindex : null;
+                        if ($catindex && strlen(trim($catindex)) > 0) {
+                            $display = $this->selected . ' ' . trim($catindex);
+                        } elseif ($main) {
+                            $cat = $this->selected;
+                            if (stripos($main, $cat) === 0) {
+                                $display = $main;
+                            } else {
+                                $display = $cat . ' ' . $main;
+                            }
+                        } else {
+                            continue;
+                        }
+                        $displayNames[$r->slug] = $display;
+                    }
+
+                    // legacy join fallback
+                    try {
+                        $joinedOld = DB::connection('mysqlOld')->table('objects as o')
+                            ->join('objectnames as n', function ($join) {
+                                $join->on('o.name', '=', 'n.objectname')->orOn('o.name', '=', 'n.altname');
+                            })
+                            ->whereIn('o.slug', $missing)
+                            ->whereIn('n.catalog', $catalogVariants)
+                            ->select('o.slug', 'n.objectname', 'n.altname', 'n.catindex')
+                            ->get();
+
+                        foreach ($joinedOld as $r) {
+                            if (isset($displayNames[$r->slug]))
+                                continue;
+                            $main = $r->objectname ?: $r->altname;
+                            $catindex = property_exists($r, 'catindex') ? $r->catindex : null;
+                            if ($catindex && strlen(trim($catindex)) > 0) {
+                                $display = $this->selected . ' ' . trim($catindex);
+                            } elseif ($main) {
+                                $cat = $this->selected;
+                                if (stripos($main, $cat) === 0) {
+                                    $display = $main;
+                                } else {
+                                    $display = $cat . ' ' . $main;
+                                }
+                            } else {
+                                continue;
+                            }
+                            $displayNames[$r->slug] = $display;
+                        }
+                    } catch (\Throwable $_) {
+                        // ignore
+                    }
+                }
+
+                // Finally, ensure every slug has at least the main object name
+                $objsMap = collect($objects->items())->mapWithKeys(function ($o) {
+                    return [$o->slug => $o->name]; })->toArray();
+                foreach ($objsMap as $slug => $mainName) {
+                    if (!isset($displayNames[$slug]) || empty($displayNames[$slug])) {
+                        $displayNames[$slug] = $mainName;
+                    } else {
+                        $display = $displayNames[$slug];
+                        // Do not duplicate when display already contains the main name (case-insensitive)
+                        if (stripos($display, $mainName) === false) {
+                            $displayNames[$slug] = $display . ' (' . $mainName . ')';
+                        } else {
+                            $displayNames[$slug] = $display;
+                        }
+                    }
+                }
+            }
+        }
+
+        return view('livewire.catalogs-page', [
+            'catalogs' => $catalogs,
+            'constellationCounts' => $constellationCounts,
+            'typeCounts' => $typeCounts,
+            'objects' => $objects,
+            'displayNames' => isset($displayNames) ? $displayNames : [],
+        ]);
+    }
+}

--- a/deepskylog/resources/views/catalogs/index.blade.php
+++ b/deepskylog/resources/views/catalogs/index.blade.php
@@ -1,0 +1,5 @@
+@extends('layouts.app')
+
+@section('content')
+    <livewire:catalogs-page />
+@endsection

--- a/deepskylog/resources/views/components/menu/view-dropdown.blade.php
+++ b/deepskylog/resources/views/components/menu/view-dropdown.blade.php
@@ -44,7 +44,7 @@
 
             <x-menu.item icon="chart-bar-square" href="{{ config('app.old_url') }}/index.php?indexAction=statistics">{{ __('Statistics') }}</x-menu.item>
 
-            <x-menu.item separator icon="pencil-square" href="{{ config('app.old_url') }}/index.php?indexAction=view_catalogs" data-last>{{ __('Catalogs') }}</x-menu.item>
+            <x-menu.item separator icon="pencil-square" href="{{ url('/catalogs') }}" data-last>{{ __('Catalogs') }}</x-menu.item>
 
         </x-menu.dropdown>
     </div>

--- a/deepskylog/resources/views/components/menu/view-responsive-dropdown.blade.php
+++ b/deepskylog/resources/views/components/menu/view-responsive-dropdown.blade.php
@@ -67,7 +67,7 @@
             <x-dropdown.item
                 separator
                 icon="pencil-square"
-                href="{{ config('app.old_url') }}/index.php?indexAction=view_catalogs"
+                href="{{ url('/catalogs') }}"
                 label="{{ __('Catalogs') }}"
             />
         </div>

--- a/deepskylog/resources/views/livewire/catalogs-page.blade.php
+++ b/deepskylog/resources/views/livewire/catalogs-page.blade.php
@@ -1,0 +1,142 @@
+<div class="p-6 max-w-6xl">
+    <h1 class="text-2xl font-semibold text-gray-200">{{ __('Catalogs') }}</h1>
+    <p class="mt-1 text-sm text-gray-400">{{ __('Select a catalog to view object counts by constellation, types and objects list.') }}</p>
+
+    <div class="mt-6">
+        <div x-data="{ open: @entangle('open'), active: -1, query: @entangle('search') }" @keydown.escape="open=false" class="relative">
+            <label class="block text-sm font-medium text-gray-400 mb-1">{{ __('Catalog') }}</label>
+            <input
+                x-ref="input"
+                x-on:focus="open=true"
+                x-on:click="open=true"
+                x-on:input="open = true; active = -1"
+                x-on:keydown.arrow-down.prevent="if($refs.list && $refs.list.children.length) active = Math.min(active + 1, $refs.list.children.length - 1)"
+                x-on:keydown.arrow-up.prevent="if($refs.list && $refs.list.children.length) active = Math.max(active - 1, 0)"
+                x-on:keydown.enter.prevent="if(active >= 0 && $refs.list) $wire.selectCatalog($refs.list.children[active].dataset.value); open=false"
+                wire:model.debounce.250ms="search"
+                type="text"
+                placeholder="e.g. NGC, IC, M"
+                class="block w-full rounded border border-gray-600 bg-gray-900 text-gray-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+
+            <div x-show="open" x-cloak @click.away="open = false" class="absolute z-20 mt-1 w-full bg-gray-900 border border-gray-700 rounded max-h-64 overflow-auto">
+                <ul x-ref="list" role="listbox" class="py-1">
+                    <div wire:loading wire:target="search" class="px-3 py-2 text-sm text-gray-400">{{ __('Searching...') }}</div>
+
+                    @if($catalogs->isEmpty())
+                        <li class="px-3 py-2 text-sm text-gray-400">{{ __('No catalogs found') }}</li>
+                    @else
+                        @foreach($catalogs as $i => $cat)
+                            <li
+                                role="option"
+                                aria-selected="false"
+                                data-value="{{ $cat }}"
+                                @click.prevent="$wire.selectCatalog('{{ $cat }}'); open=false"
+                                @mouseenter="active = {{ $i }}"
+                                x-show="query === '' || ($el.dataset.value && $el.dataset.value.toLowerCase().includes(query.toLowerCase()))"
+                                x-bind:aria-hidden="!(query === '' || ($el.dataset.value && $el.dataset.value.toLowerCase().includes(query.toLowerCase())))"
+                                class="px-3 py-2 cursor-pointer text-sm hover:bg-gray-800 hover:text-white"
+                                :class="{'bg-gray-800 text-white': active === {{ $i }}}"
+                            >
+                                {{ $cat }}
+                            </li>
+                        @endforeach
+                    @endif
+                </ul>
+            </div>
+
+            <div class="mt-3 flex gap-3">
+                <button @click.prevent="$wire.selectCatalog($refs.input.value); open=false" class="inline-flex items-center gap-2 bg-blue-700 text-white px-4 py-2 rounded hover:bg-blue-600">{{ __('Show') }}</button>
+                <button wire:click.prevent="clearSelection" class="inline-flex items-center bg-gray-600 text-white px-4 py-2 rounded hover:bg-gray-500">{{ __('Reset') }}</button>
+            </div>
+        </div>
+    </div>
+
+    @if($selected)
+        <div class="mt-8 space-y-6">
+            <!-- Objects table: full-width at the top -->
+            <div class="bg-gray-900 rounded border border-gray-700 p-4">
+                <h2 class="font-semibold text-gray-200 mb-2">{{ __('Objects in') }} {{ $selected }}</h2>
+                @if(!$objects || $objects->isEmpty())
+                    <div class="text-sm text-gray-400">{{ __('No objects to show.') }}</div>
+                @else
+                    <div class="overflow-x-auto">
+                        <table class="w-full text-sm text-left text-gray-300">
+                            <thead>
+                            <tr>
+                                <th class="pb-2">{{ __('Name') }}</th>
+                                <th class="pb-2">{{ __('Type') }}</th>
+                                <th class="pb-2">{{ __('Constellation') }}</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            @foreach($objects as $obj)
+                                <tr class="border-t border-gray-800">
+                                    <td class="py-2">
+                                        <a href="{{ url('/object/' . $obj->slug) }}" class="text-blue-400 hover:underline">{{ $displayNames[$obj->slug] ?? $obj->name }}</a>
+                                    </td>
+                                    <td class="py-2">{{ $obj->type_name ?? '' }}</td>
+                                    <td class="py-2">{{ $obj->constellation ?? '' }}</td>
+                                </tr>
+                            @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="mt-4">{{ $objects->links() }}</div>
+                @endif
+            </div>
+
+            <!-- Below: constellations and types side-by-side on medium+, stacked on small -->
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div class="bg-gray-900 rounded border border-gray-700 p-4">
+                    <h2 class="font-semibold text-gray-200 mb-2">{{ __('Objects per constellation') }}</h2>
+                    @if($constellationCounts->isEmpty())
+                        <div class="text-sm text-gray-400">{{ __('No objects found in this catalog.') }}</div>
+                    @else
+                        <table class="w-full text-sm text-left text-gray-300">
+                            <thead>
+                            <tr>
+                                <th class="pb-2">{{ __('Constellation') }}</th>
+                                <th class="pb-2">{{ __('Count') }}</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            @foreach($constellationCounts as $row)
+                                <tr class="border-t border-gray-800">
+                                    <td class="py-2">{{ $row->constellation }}</td>
+                                    <td class="py-2">{{ $row->total }}</td>
+                                </tr>
+                            @endforeach
+                            </tbody>
+                        </table>
+                    @endif
+                </div>
+
+                <div class="bg-gray-900 rounded border border-gray-700 p-4">
+                    <h2 class="font-semibold text-gray-200 mb-2">{{ __('Types') }}</h2>
+                    @if($typeCounts->isEmpty())
+                        <div class="text-sm text-gray-400">{{ __('No type information available.') }}</div>
+                    @else
+                        <table class="w-full text-sm text-left text-gray-300">
+                            <thead>
+                            <tr>
+                                <th class="pb-2">{{ __('Type') }}</th>
+                                <th class="pb-2">{{ __('Count') }}</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            @foreach($typeCounts as $row)
+                                <tr class="border-t border-gray-800">
+                                    <td class="py-2">{{ $row->type_name ?? __('Unknown') }}</td>
+                                    <td class="py-2">{{ $row->total }}</td>
+                                </tr>
+                            @endforeach
+                            </tbody>
+                        </table>
+                    @endif
+                </div>
+            </div>
+        </div>
+    @endif
+</div>

--- a/deepskylog/routes/web.php
+++ b/deepskylog/routes/web.php
@@ -374,6 +374,10 @@ Route::post('/object', [App\Http\Controllers\ObjectController::class, 'store'])
 Route::get('/object/{slug}', [App\Http\Controllers\ObjectController::class, 'show'])
     ->name('object.show')->middleware('doNotCacheResponse');
 
+// Catalogs overview page
+Route::get('/catalogs', [App\Http\Controllers\CatalogController::class, 'index'])
+    ->name('catalogs.index');
+
 // Edit object (only for admins and database experts)
 Route::get('/object/{slug}/edit', [App\Http\Controllers\ObjectController::class, 'edit'])
     ->name('object.edit')->middleware(['auth', 'doNotCacheResponse']);


### PR DESCRIPTION
Adds a browsable catalogs overview with a Livewire-powered search/selection UI and paginated objects list, including counts by constellation and type.

Provides robust backend resolution of catalog variants and object slugs, merging data from the primary and legacy databases and falling back to name-based matching; orders results by numeric catalog index when available and prevents invalid queries when no matches exist.

Updates navigation and routes to expose the new page and includes minor TODO note about session performance.