### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Here's what you can do to help:
 
 ## Code submission and pull request guidelines
 
-+ Your code will be checked for clean code using [php codesniffer](https://github.com/squizlabs/PHP_CodeSniffer).
++ Your code will be checked for clean code using [php codesniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer).
 + Test unit tests will also be executed automatically.
 + It is not mandatory but highly appreciated if you provide **test cases** and/or performance tests (we recommend
   using [phpunit](https://phpunit.de/)).


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932