### PR TITLE
Prevents horizontal overflow on object detail view

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -4,7 +4,7 @@
 
 ## Next steps
 
-+ [ ] Update to laravel 13, vite 8.
++ [ ] Update to laravel 13.
 + [ ] Targets
   + [ ] Search targets
     + [ ] Main search page: first by name, then by type, constellation, ...

--- a/deepskylog/resources/views/object/show.blade.php
+++ b/deepskylog/resources/views/object/show.blade.php
@@ -1,4 +1,17 @@
 <x-app-layout>
+    <style>
+        /* Prevent horizontal page scroll on the object detail page.
+           In flex-row (lg+): min-width:0 keeps the flex item within its
+           allocated space when child content is wide.
+           In flex-col (<lg): items-start means the item is not auto-stretched,
+           so max-width:100% is required to cap its width to the parent container.
+           overflow-x:hidden clips any residual overflow from within the item. */
+        [data-dsl-main-content] {
+            min-width: 0;
+            max-width: 100%;
+            overflow-x: hidden;
+        }
+    </style>
     <div>
         <!-- Use a wider container so the object details area can take more horizontal space.
            Switched from max-w-7xl to max-w-screen-xl which uses more of the viewport on large screens. -->


### PR DESCRIPTION
Adds inline layout CSS to cap flex-item width and hide horizontal overflow so the object detail page no longer produces horizontal page scroll in responsive layouts. Removes the Vite 8 note from the to-do list, leaving Laravel 13 as the current update target.