### PR TITLE
Improve comet sketch lookup and preload objects

### DIFF
--- a/deepskylog/resources/views/components/sketch-comet.blade.php
+++ b/deepskylog/resources/views/components/sketch-comet.blade.php
@@ -1,21 +1,19 @@
 {{-- Avoid inline `use` in Blade; use fully-qualified class names instead --}}
-@props(["observation_id" => null, "observer_name" => null, "observer_username" => null, "observation_date" => null])
+@props(["observation_id" => null, "observer_name" => null, "observer_username" => null, "observation_date" => null, "preloaded_comet" => null])
 <div>
     @php
-        $obs = \App\Models\CometObservationsOld::find($observation_id);
-        $comet = $obs && isset($obs->object) ? \App\Models\CometObject::where('id', $obs->object->id)->first() : null;
-        $cometName = $comet?->name ?? ($obs?->object->name ?? __('Unknown comet'));
+        $comet = $preloaded_comet ?? \App\Models\CometObject::where('id', function($q) use ($observation_id) {
+            $q->select('objectid')->from('cometobservations')->where('id', $observation_id)->limit(1);
+        })->first();
+        $cometName = $comet?->name ?? __('Unknown comet');
         $slug = $comet?->slug ?? \Illuminate\Support\Str::slug($cometName ?? '', '-');
         $objectUrl = route('object.show', $slug);
+        $objectName = $cometName;
     @endphp
     <a class="no-underline" href="{{ $objectUrl }}">
         <img width="400" src="/images/cometdrawings/{{ $observation_id }}.jpg"/>
 
         <div class="text-center">
-            @php
-                $obs = \App\Models\CometObservationsOld::find($observation_id);
-                $objectName = $obs && isset($obs->object) ? ($obs->object->name ?? __('Unknown')) : __('Unknown');
-            @endphp
             {{ $observer_name }} - {{ $objectName }}
             -
             {{ \Carbon\Carbon::create($observation_date)->translatedFormat("j M Y") }}
@@ -54,8 +52,6 @@
         </button>
 
             @php
-                $obs = \App\Models\CometObservationsOld::find($observation_id);
-                $objectName = $obs && isset($obs->object) ? ($obs->object->name ?? __('Unknown')) : __('Unknown');
                 $messageSubject = __('About your sketch of :object', ['object' => $objectName]);
             @endphp
 

--- a/deepskylog/resources/views/object/show.blade.php
+++ b/deepskylog/resources/views/object/show.blade.php
@@ -1062,76 +1062,50 @@ try {
 
                             {{-- Sketches that were DeepskyLog sketch(s) of the week for this object --}}
                             @php
-                                // The observations legacy table lives on the mysqlOld connection.
-                                // Build a list of observation ids from the legacy DB matching this object's name
 $objectSketches = collect();
 try {
-    $objName = $session->name ?? '';
-    if (!empty($objName)) {
-        $obsIds = \Illuminate\Support\Facades\DB::connection('mysqlOld')
-            ->table('observations')
-            ->where('objectname', $objName)
-            ->pluck('id')
-            ->toArray();
+    $isComet = strtolower(trim((string) ($session->source_type_raw ?? ''))) === 'comet';
 
-        if (!empty($obsIds)) {
-            $objectSketches = \App\Models\SketchOfTheWeek::whereIn('observation_id', $obsIds)
-                ->orderByDesc('date')
-                ->get();
-        } elseif (strtolower(trim((string) ($session->source_type_raw ?? ''))) === 'comet') {
-            // Fallback tokenized LIKE search is only for comets, whose names may differ
-            // slightly between tables. For regular deepsky objects with no recorded
-            // observations, leave $objectSketches empty rather than doing a broad LIKE
-            // match that would catch unrelated objects.
-            try {
-                $simple = preg_replace('/[^A-Za-z0-9 ]+/', ' ', $objName);
-                $tokens = array_filter(array_map('trim', preg_split('/\s+/', $simple)));
-                if (!empty($tokens)) {
-                    $q = \Illuminate\Support\Facades\DB::connection('mysqlOld')->table('observations');
-                    $first = array_shift($tokens);
-                    $q->where('objectname', 'like', '%' . $first . '%');
-                    foreach ($tokens as $t) {
-                        $q->orWhere('objectname', 'like', '%' . $t . '%');
-                    }
-                    $altIds = $q->pluck('id')->toArray();
-                    if (!empty($altIds)) {
-                        $objectSketches = \App\Models\SketchOfTheWeek::whereIn('observation_id', $altIds)
-                            ->orderByDesc('date')
-                            ->get();
-                    }
-                }
-            } catch (\Throwable $_) {
-                // ignore fallback failures
+    if ($isComet) {
+        // For comet pages, use the comet object ID directly to avoid cross-comet false matches.
+        // sketch_of_the_week stores comet observations as negative observation_id values
+        // (i.e. observation_id = -cometobservations.id).
+        $cometObjectId = $session->id ?? null;
+        if (!empty($cometObjectId)) {
+            $cometObsIds = \Illuminate\Support\Facades\DB::connection('mysqlOld')
+                ->table('cometobservations')
+                ->where('objectid', $cometObjectId)
+                ->pluck('id')
+                ->toArray();
+
+            if (!empty($cometObsIds)) {
+                $negativeCometObsIds = array_map(fn($id) => -$id, $cometObsIds);
+                $objectSketches = \App\Models\SketchOfTheWeek::whereIn('observation_id', $negativeCometObsIds)
+                    ->orderByDesc('date')
+                    ->get();
             }
-            // Also check sketch_of_the_week entries that reference cometobservations
-            try {
-                $tokensForLike = [];
-                if (!empty($tokens)) {
-                    foreach ($tokens as $t) {
-                        $tokensForLike[] = '%' . $t . '%';
-                    }
-                } else {
-                    $tokensForLike[] = '%' . $objName . '%';
-                }
-                // Build WHERE clause for tokenized matching on cometobjects.name
-                $likes = implode(' OR ', array_fill(0, count($tokensForLike), 'coo.name LIKE ?'));
-                $sql = 'SELECT s.* FROM sketch_of_the_week s JOIN deepskylog.cometobservations co ON co.id = -s.observation_id JOIN deepskylog.cometobjects coo ON coo.id = co.objectid WHERE ' . $likes . ' ORDER BY s.date DESC';
-                $cometRows = \Illuminate\Support\Facades\DB::select($sql, $tokensForLike);
-                if (!empty($cometRows)) {
-                    foreach ($cometRows as $r) {
-                        // convert stdClass row to Eloquent model for the view helper x-sketch
-                        $objectSketches->push(\App\Models\SketchOfTheWeek::find($r->id));
-                    }
-                }
-            } catch (\Throwable $_) {
-                // ignore
+        }
+    } else {
+        // For deepsky objects, match by exact object name in the legacy observations table.
+        $objName = $session->name ?? '';
+        if (!empty($objName)) {
+            $obsIds = \Illuminate\Support\Facades\DB::connection('mysqlOld')
+                ->table('observations')
+                ->where('objectname', $objName)
+                ->pluck('id')
+                ->toArray();
+
+            if (!empty($obsIds)) {
+                $objectSketches = \App\Models\SketchOfTheWeek::whereIn('observation_id', $obsIds)
+                    ->orderByDesc('date')
+                    ->get();
             }
         }
     }
 } catch (\Throwable $_) {
     // Fail silently: keep $objectSketches empty so the section simply doesn't render
-                                    $objectSketches = collect();
-                                }
+    $objectSketches = collect();
+}
                             @endphp
 
                             @if ($objectSketches->isNotEmpty())

--- a/deepskylog/resources/views/welcome.blade.php
+++ b/deepskylog/resources/views/welcome.blade.php
@@ -272,6 +272,9 @@
 
                 $observerIds = $sketches->pluck('observerid')->unique()->values()->all();
                 $observerUsers = User::whereIn('username', $observerIds)->get()->keyBy('username');
+
+                $sketchObjectIds = $sketches->pluck('objectid')->unique()->filter()->values()->all();
+                $preloadedSketchComets = \App\Models\CometObject::whereIn('id', $sketchObjectIds)->get()->keyBy('id');
             @endphp
 
             <div class="mt-2">
@@ -292,6 +295,7 @@
                                     :observer_name="$observer_name"
                                     :observer_username="$sketch->observerid"
                                     :observation_date="$observation_date"
+                                    :preloaded_comet="$preloadedSketchComets[$sketch->objectid] ?? null"
                                 />
                             </div>
                         @endforeach


### PR DESCRIPTION
Uses comet object IDs to locate sketches and maps legacy comet observation IDs to negative sketch references so comet pages match correctly. Uses exact legacy observation name matching for non-comet pages and removes a brittle tokenized name fallback and expensive raw joins. Preloads comet objects for sketch listings and updates the sketch component to accept a preloaded model, eliminating redundant per-item DB queries and improving accuracy and performance.