### PR TITLE
Disables in-memory engine for indexing

### DIFF
--- a/deepskylog/app/Console/Commands/TntsearchIncrementalIndex.php
+++ b/deepskylog/app/Console/Commands/TntsearchIncrementalIndex.php
@@ -47,10 +47,12 @@ class TntsearchIncrementalIndex extends Command
         $tnt->loadConfig(['driver' => 'sqlite', 'database' => $dbFile, 'storage' => $storage]);
         try {
             $tnt->selectIndex('search_index');
+            $tnt->engine->inMemory = false;
             $indexer = new TNTIndexer($tnt->engine);
             $indexer->loadConfig(['driver' => 'sqlite', 'database' => $dbFile, 'storage' => $storage]);
         } catch (IndexNotFoundException $e) {
             $this->info('Index not found, creating new index `search_index`.');
+            $tnt->engine->inMemory = false;
             $indexer = new TNTIndexer($tnt->engine);
             $indexer->loadConfig(['driver' => 'sqlite', 'database' => $dbFile, 'storage' => $storage]);
             $indexer->createIndex('search_index');


### PR DESCRIPTION
Disables the engine's in-memory mode before selecting or creating the search index so the indexer uses persistent (SQLite) storage. Prevents transient in-memory indexes and ensures index data is written to disk.