### PR TITLE
Processes alt names matching object name

### DIFF
--- a/deepskylog/app/Http/Controllers/ObjectController.php
+++ b/deepskylog/app/Http/Controllers/ObjectController.php
@@ -3942,8 +3942,7 @@ class ObjectController extends Controller
                 ]);
 
                 foreach ($altNames as $altName) {
-                    if (!empty($altName) && $altName !== $object->name) {
-                        // Skip if this is the same as the object name itself
+                    if (!empty($altName)) {
 
                         // Parse catalog and catindex from altname
                         // Expected formats: "NGC 3623", "M 65", "IC 1234", etc.


### PR DESCRIPTION
Removes the check that skipped alt names identical to the object's main name so all non-empty alt names are parsed for catalog/catindex extraction. Ensures consistent parsing/normalization and avoids missing metadata when an alt name equals the primary name.