### PR TITLE
Caches translations on demand

### DIFF
--- a/deepskylog/resources/views/components/observation-deepsky.blade.php
+++ b/deepskylog/resources/views/components/observation-deepsky.blade.php
@@ -209,9 +209,17 @@
                     @if (auth()->user() && auth()->user()->translate && ($observation->language ?? 'nl') !== auth()->user()->language)
                         @php
                             $cacheKey = 'observation_deepsky_translation:' . $observation->id . ':' . auth()->user()->language;
-                            // Non-blocking: serve from cache if available, otherwise show original.
-                            // A background job (TranslateObservationDescriptions) populates the cache asynchronously.
-                            $translated = Cache::get($cacheKey);
+                            $translated = Cache::remember($cacheKey, now()->addDays(30), function () use ($observation, $tr) {
+                                if ($tr === null || empty($observation->description)) {
+                                    return null;
+                                }
+
+                                try {
+                                    return $tr->translate(html_entity_decode($observation->description));
+                                } catch (\Throwable $e) {
+                                    return null;
+                                }
+                            });
                         @endphp
                         {!! $translated ?? html_entity_decode($observation->description) !!}
                     @else


### PR DESCRIPTION
Attempts to translate observation descriptions when a cached translation is missing and stores results for 30 days, instead of only serving pre-populated cache entries. Skips translation if no translator is available or the description is empty, and catches errors to safely fall back to the original text. Reduces reliance on the asynchronous background job and improves translation availability without blocking the UI.