### PR TITLE
Grants Database Experts access to admin object checks

### DIFF
--- a/deepskylog/app/Http/Controllers/AdminObjectCheckController.php
+++ b/deepskylog/app/Http/Controllers/AdminObjectCheckController.php
@@ -90,6 +90,9 @@ class AdminObjectCheckController extends Controller
 
     private function ensureAdministrator(): void
     {
-        abort_unless(Auth::check() && Auth::user()->isAdministrator(), 403);
+        abort_unless(
+            Auth::check() && (Auth::user()->isAdministrator() || Auth::user()->isDatabaseExpert()),
+            403
+        );
     }
 }

--- a/deepskylog/resources/views/components/menu/admin-dropdown.blade.php
+++ b/deepskylog/resources/views/components/menu/admin-dropdown.blade.php
@@ -18,7 +18,7 @@
 
                     <x-menu.item icon="plus" href="/sketch-of-the-month/create">{{ __('Add sketch of the month') }}</x-menu.item>
 
-                    @if (Auth::user()->isAdministrator())
+                    @if (Auth::user()->isAdministrator() || Auth::user()->isDatabaseExpert())
                         <x-menu.item separator icon="check-badge" href="{{ route('admin.objects.check') }}">{{ __('Check Objects') }}</x-menu.item>
                     @endif
 

--- a/deepskylog/resources/views/components/menu/admin-responsive-dropdown.blade.php
+++ b/deepskylog/resources/views/components/menu/admin-responsive-dropdown.blade.php
@@ -39,7 +39,7 @@
                         label="{{ __('Add sketch of the month') }}"
                     />
 
-                    @if (Auth::user()->isAdministrator())
+                    @if (Auth::user()->isAdministrator() || Auth::user()->isDatabaseExpert())
                         <x-dropdown.item
                             icon="check-badge"
                             separator

--- a/deepskylog/tests/Feature/AdminObjectCheckTest.php
+++ b/deepskylog/tests/Feature/AdminObjectCheckTest.php
@@ -64,6 +64,15 @@ test('administrator can view the local check objects page', function () {
         ->assertSee('Objects and object names');
 });
 
+test('database expert can view the local check objects page', function () {
+    $user = $this->createUserAndAssignToTeam('Database Experts');
+
+    $this->actingAs($user)
+        ->get(route('admin.objects.check'))
+        ->assertOk()
+        ->assertSee('Check Objects');
+});
+
 test('administrator can delete orphan object names', function () {
     $user = $this->createUserAndAssignToTeam('Administrators');
 
@@ -136,6 +145,14 @@ test('administrator can delete orphan object names', function () {
 
 test('administrator can trigger observation object-name repair', function () {
     $user = $this->createUserAndAssignToTeam('Administrators');
+
+    $this->actingAs($user)
+        ->post(route('admin.objects.check.repair-observation-objectnames'))
+        ->assertRedirect(route('admin.objects.check'));
+});
+
+test('database expert can trigger observation object-name repair', function () {
+    $user = $this->createUserAndAssignToTeam('Database Experts');
 
     $this->actingAs($user)
         ->post(route('admin.objects.check.repair-observation-objectnames'))


### PR DESCRIPTION
Allows Database Experts to access the object-check UI and trigger repair actions previously limited to Administrators. Updates authorization guard and menu visibility to include the Database Experts role and adds feature tests to verify view and repair permissions.