### PR TITLE
Skips importing observing lists with empty names

### DIFF
--- a/deepskylog/app/Services/ObservingListImportService.php
+++ b/deepskylog/app/Services/ObservingListImportService.php
@@ -75,6 +75,11 @@ class ObservingListImportService
      */
     protected function importObservingList($legacyList, bool $dryRun): void
     {
+        // Skip lists with empty list names (they cannot generate a valid slug)
+        if (empty(trim($legacyList->listname ?? ''))) {
+            return;
+        }
+
         // Map username to user_id
         $user = User::where('username', $legacyList->observerid)->first();
 


### PR DESCRIPTION
Skips lists with empty or whitespace-only names to prevent generating invalid slugs during import.

Silently ignores such legacy records to avoid import errors and ensure only valid lists are processed.