### PR TITLE
Adds comment notifications and SQLite migration

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -5,19 +5,18 @@
 ## Next steps
 
 + [ ] Update to laravel 13.
-+ [ ] Observing lists
-  + [ ] Use new tables in old version of DeepskyLog
-+ [ ] Release new version of pyDeepskyLog
-  + [ ] Should add a method to get the locations of a user, but only if authentication is implemented.
-
-### Distant future
-
 + [ ] Observations
   + [ ] Comment on observations
   + [ ] Like observations
   + [ ] Add observations of other objects: planets, comets, lunar features, ...
   + [ ] Show detailed observation page, with all details, comments, ...
+  + [ ] Import / export observations in a file, like the one used by SkySafari, AstroPlanner, Argo Navis, OAL, ...
   + [ ] Feeds: <https://laravel-news.com/learn-to-create-an-rss-feeds-from-scratch-in-laravel>
++ [ ] Release new version of pyDeepskyLog
+  + [ ] Should add a method to get the locations of a user, but only if authentication is implemented.
+
+### Distant future
+
 + [ ] All missing pages
 
 

--- a/deepskylog/app/Http/Controllers/ObservingListController.php
+++ b/deepskylog/app/Http/Controllers/ObservingListController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\ObservingList;
 use App\Models\ObservingListComment;
 use App\Models\ObservingListItem;
+use App\Models\Message;
 use App\Models\ObservationsOld;
 use App\Models\ObjectsOld;
 use App\Models\User;
@@ -16,8 +17,9 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Validator;
 
 class ObservingListController extends Controller
 {
@@ -899,6 +901,51 @@ class ObservingListController extends Controller
         ]);
 
         $list->addComment($user, $validated['body']);
+
+        // Notify the list owner via internal DeepskyLog message (skip self-comments).
+        if ((int) $list->owner_user_id !== (int) $user->id) {
+            try {
+                $list->loadMissing('owner');
+
+                $ownerUsername = $list->owner?->username;
+                if (!empty($ownerUsername)) {
+                    $subject = __('New comment on your observing list: :list', [
+                        'list' => html_entity_decode($list->name, ENT_QUOTES | ENT_HTML5, 'UTF-8'),
+                    ]);
+
+                    $commentPreview = trim(strip_tags($validated['body']));
+                    if (mb_strlen($commentPreview) > 300) {
+                        $commentPreview = mb_substr($commentPreview, 0, 300) . '...';
+                    }
+
+                    $listUrl = route('observing-list.show', ['list' => $list]);
+                    $messageHtml = '<p>' . e(__('User :user commented on your observing list ":list".', [
+                        'user' => $user->username,
+                        'list' => html_entity_decode($list->name, ENT_QUOTES | ENT_HTML5, 'UTF-8'),
+                    ])) . '</p>';
+
+                    if ($commentPreview !== '') {
+                        $messageHtml .= '<p><strong>' . e(__('Comment')) . ':</strong> ' . e($commentPreview) . '</p>';
+                    }
+
+                    $messageHtml .= '<p><a href="' . e($listUrl) . '">' . e(__('Open observing list')) . '</a></p>';
+
+                    Message::create([
+                        'sender' => $user->username ?: 'deepskylog',
+                        'receiver' => $ownerUsername,
+                        'subject' => Message::sanitizeHtml($subject),
+                        'message' => Message::sanitizeHtml($messageHtml),
+                        'date' => now(),
+                    ]);
+                }
+            } catch (\Throwable $e) {
+                Log::warning('Failed to send observing list comment notification', [
+                    'list_id' => $list->id,
+                    'commenter_id' => $user->id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
 
         return redirect()->back()->with('success', __('Comment added.'));
     }

--- a/deepskylog/database/migrations/2026_04_23_000001_add_sort_order_to_observing_list_items_and_create_observerobjectlist_view.php
+++ b/deepskylog/database/migrations/2026_04_23_000001_add_sort_order_to_observing_list_items_and_create_observerobjectlist_view.php
@@ -18,53 +18,108 @@ return new class extends Migration {
      */
     public function up(): void
     {
+        $driver = DB::getDriverName();
+
         // 1. Add sort_order column
-        Schema::table('observing_list_items', function (Blueprint $table) {
-            $table->unsignedInteger('sort_order')->default(0)->after('item_description');
-            $table->index(['observing_list_id', 'sort_order'], 'idx_list_sort');
-        });
+        if ($driver === 'sqlite') {
+            Schema::table('observing_list_items', function (Blueprint $table) {
+                $table->unsignedInteger('sort_order')->default(0);
+                $table->index(['observing_list_id', 'sort_order'], 'idx_list_sort');
+            });
+        } else {
+            Schema::table('observing_list_items', function (Blueprint $table) {
+                $table->unsignedInteger('sort_order')->default(0)->after('item_description');
+                $table->index(['observing_list_id', 'sort_order'], 'idx_list_sort');
+            });
+        }
 
         // 2. Populate sort_order based on insertion order within each list
-        DB::statement('
-            UPDATE observing_list_items oli
-            JOIN (
-                SELECT id,
-                       ROW_NUMBER() OVER (PARTITION BY observing_list_id ORDER BY id) AS rn
-                FROM observing_list_items
-            ) ranked ON oli.id = ranked.id
-            SET oli.sort_order = ranked.rn
-        ');
+        if ($driver === 'sqlite') {
+            DB::statement('
+                UPDATE observing_list_items
+                SET sort_order = (
+                    SELECT COUNT(*)
+                    FROM observing_list_items i2
+                    WHERE i2.observing_list_id = observing_list_items.observing_list_id
+                      AND i2.id <= observing_list_items.id
+                )
+            ');
+        } else {
+            DB::statement('
+                UPDATE observing_list_items oli
+                JOIN (
+                    SELECT id,
+                           ROW_NUMBER() OVER (PARTITION BY observing_list_id ORDER BY id) AS rn
+                    FROM observing_list_items
+                ) ranked ON oli.id = ranked.id
+                SET oli.sort_order = ranked.rn
+            ');
+        }
 
         // 3. Create compatibility VIEW for the legacy PHP app
-        DB::statement('
-            CREATE OR REPLACE VIEW observerobjectlist AS
-            -- List "header" rows: objectplace=0, objectname=\'\'
-            SELECT
-                u.username      AS observerid,
-                \'\'            AS objectname,
-                ol.name         AS listname,
-                0               AS objectplace,
-                \'\'            AS objectshowname,
-                COALESCE(ol.description, \'\') AS description,
-                COALESCE(DATE_FORMAT(ol.created_at, \'%Y%m%d%H%i%S\'), \'\') AS timestamp,
-                ol.public       AS public
-            FROM observing_lists ol
-            JOIN users u ON u.id = ol.owner_user_id
-            UNION ALL
-            -- Item rows: objectplace = sort_order
-            SELECT
-                u.username      AS observerid,
-                oli.object_name AS objectname,
-                ol.name         AS listname,
-                oli.sort_order  AS objectplace,
-                oli.object_name AS objectshowname,
-                COALESCE(oli.item_description, \'\') AS description,
-                COALESCE(DATE_FORMAT(oli.created_at, \'%Y%m%d%H%i%S\'), \'\') AS timestamp,
-                ol.public       AS public
-            FROM observing_list_items oli
-            JOIN observing_lists ol ON ol.id = oli.observing_list_id
-            JOIN users u ON u.id = ol.owner_user_id
-        ');
+        DB::statement('DROP VIEW IF EXISTS observerobjectlist');
+
+        if ($driver === 'sqlite') {
+            DB::statement('
+                CREATE VIEW observerobjectlist AS
+                -- List "header" rows: objectplace=0, objectname=\'\'
+                SELECT
+                    u.username      AS observerid,
+                    \'\'            AS objectname,
+                    ol.name         AS listname,
+                    0               AS objectplace,
+                    \'\'            AS objectshowname,
+                    COALESCE(ol.description, \'\') AS description,
+                    COALESCE(strftime(\'%Y%m%d%H%M%S\', ol.created_at), \'\') AS timestamp,
+                    ol.public       AS public
+                FROM observing_lists ol
+                JOIN users u ON u.id = ol.owner_user_id
+                UNION ALL
+                -- Item rows: objectplace = sort_order
+                SELECT
+                    u.username      AS observerid,
+                    oli.object_name AS objectname,
+                    ol.name         AS listname,
+                    oli.sort_order  AS objectplace,
+                    oli.object_name AS objectshowname,
+                    COALESCE(oli.item_description, \'\') AS description,
+                    COALESCE(strftime(\'%Y%m%d%H%M%S\', oli.created_at), \'\') AS timestamp,
+                    ol.public       AS public
+                FROM observing_list_items oli
+                JOIN observing_lists ol ON ol.id = oli.observing_list_id
+                JOIN users u ON u.id = ol.owner_user_id
+            ');
+        } else {
+            DB::statement('
+                CREATE OR REPLACE VIEW observerobjectlist AS
+                -- List "header" rows: objectplace=0, objectname=\'\'
+                SELECT
+                    u.username      AS observerid,
+                    \'\'            AS objectname,
+                    ol.name         AS listname,
+                    0               AS objectplace,
+                    \'\'            AS objectshowname,
+                    COALESCE(ol.description, \'\') AS description,
+                    COALESCE(DATE_FORMAT(ol.created_at, \'%Y%m%d%H%i%S\'), \'\') AS timestamp,
+                    ol.public       AS public
+                FROM observing_lists ol
+                JOIN users u ON u.id = ol.owner_user_id
+                UNION ALL
+                -- Item rows: objectplace = sort_order
+                SELECT
+                    u.username      AS observerid,
+                    oli.object_name AS objectname,
+                    ol.name         AS listname,
+                    oli.sort_order  AS objectplace,
+                    oli.object_name AS objectshowname,
+                    COALESCE(oli.item_description, \'\') AS description,
+                    COALESCE(DATE_FORMAT(oli.created_at, \'%Y%m%d%H%i%S\'), \'\') AS timestamp,
+                    ol.public       AS public
+                FROM observing_list_items oli
+                JOIN observing_lists ol ON ol.id = oli.observing_list_id
+                JOIN users u ON u.id = ol.owner_user_id
+            ');
+        }
     }
 
     /**

--- a/deepskylog/tests/Feature/ObservingListCommentNotificationTest.php
+++ b/deepskylog/tests/Feature/ObservingListCommentNotificationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Models\Message;
+use App\Models\ObservingList;
+use App\Models\User;
+
+it('sends an internal message to the list owner when another user comments', function () {
+    $owner = User::factory()->create(['username' => 'listowner']);
+    $commenter = User::factory()->create(['username' => 'commenter']);
+
+    $list = ObservingList::create([
+        'owner_user_id' => $owner->id,
+        'name' => 'Spring Galaxies',
+        'description' => 'A compact spring list',
+        'public' => true,
+    ]);
+
+    $response = $this->actingAs($commenter)->post(route('observing-list.comments.store', ['list' => $list]), [
+        'body' => 'Great list, thanks for sharing.',
+    ]);
+
+    $response->assertSessionHas('success');
+
+    $message = Message::where('receiver', $owner->username)
+        ->where('sender', $commenter->username)
+        ->first();
+
+    expect($message)->not->toBeNull();
+    expect($message->subject)->toContain('Spring Galaxies');
+
+    $listUrl = route('observing-list.show', ['list' => $list]);
+    expect($message->message)->toContain($listUrl);
+});
+
+it('does not send a message when the owner comments on their own list', function () {
+    $owner = User::factory()->create(['username' => 'listowner']);
+
+    $list = ObservingList::create([
+        'owner_user_id' => $owner->id,
+        'name' => 'Summer Nebulae',
+        'description' => null,
+        'public' => false,
+    ]);
+
+    $response = $this->actingAs($owner)->post(route('observing-list.comments.store', ['list' => $list]), [
+        'body' => 'My own note.',
+    ]);
+
+    $response->assertSessionHas('success');
+
+    $count = Message::where('receiver', $owner->username)->count();
+    expect($count)->toBe(0);
+});


### PR DESCRIPTION
Adds internal notifications that send a sanitized, truncated HTML message to list owners when another user comments, improving owner awareness and engagement; failures are logged and do not interrupt comment creation.

Updates the migration to add a sort_order column and populate it with driver-aware SQL, and recreates the legacy compatibility view using appropriate date functions/DDL for SQLite vs other DBs to ensure cross-DB compatibility.

Adds feature tests validating notification delivery to owners and ensuring no message is sent for self-comments.